### PR TITLE
[WIP] This gets docko build to succeed, and adds some additional caching in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM node:4
+FROM node:6.3
 
-RUN useradd -u 777 -r -m -U app
 RUN mkdir -p /src/app
 WORKDIR /src/app
-COPY . /src/app
 
-RUN chown -R app:app .
-USER app
+RUN npm install -g node-inspector
+
+COPY package.json /src/app/
+RUN npm install
+
+COPY . /src/app
 
 CMD ["npm", "start"]

--- a/frontend/js/components/index.js
+++ b/frontend/js/components/index.js
@@ -1,3 +1,3 @@
-export {App} from './App'
+export {App} from './app'
 export {default as ReduxTest} from './redux-test'
 export {Foo} from './foo'


### PR DESCRIPTION
I don't think this entirely fixes everything, but it's _some_ progress.

```
webpack_1  | Child extract-text-webpack-plugin:
webpack_1  |     chunk    {0} extract-text-webpack-plugin-output-filename 1.93 kB [rendered]
webpack_1  |         [0] ./~/css-loader?sourceMap!./~/autoprefixer-loader!./~/resolve-url-loader?sourceMap&fail!./~/sass-loader?outputStyle=expanded&sourceMap=true&sourceMapContents=true!./~/import-glob-loader!./frontend/css/application.scss 424 bytes {0} [built]
webpack_1  |         [1] ./~/css-loader/lib/css-base.js 1.51 kB {0} [built]
webpack_1  | webpack: bundle is now VALID.
```

but, navigating to `localhost:8080` is just a blank/white screen.
